### PR TITLE
fix: potential error when resetElement

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -197,7 +197,8 @@ class Sticky {
     ['position', 'top', 'bottom', 'left', 'width', 'zIndex'].forEach((attr) => {
       this.el.style.removeProperty(attr)
     })
-    this.placeholderEl.parentNode.removeChild(this.placeholderEl)
+    const { parentNode } = this.placeholderEl
+    if (parentNode) { parentNode.removeChild(this.placeholderEl) }
   }
 
   getContainerEl () {


### PR DESCRIPTION
Fix a potential "Cannot read property 'removeChild' of null" error