### PR TITLE
Pause Height Recalculation when Element is Sticky

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -120,7 +120,7 @@ class Sticky {
 
   recomputeState() {
     this.state = Object.assign({}, this.state, {
-      height: this.getHeight(),
+      height: this.lastState.sticked ? this.state.height : this.getHeight(),
       width: this.getWidth(),
       xOffset: this.getXOffset(),
       placeholderElRect: this.getPlaceholderElRect(),


### PR DESCRIPTION
Latch the sticky element height to its original height while in sticky state.  May be an issue with resize events.