### PR TITLE
fix: Update position before init

### DIFF
--- a/src/sticky.js
+++ b/src/sticky.js
@@ -275,6 +275,7 @@ export default {
     if (typeof bind.value === 'undefined' || bind.value) {
       el[namespace] = new Sticky(el, vnode.context);
       el[namespace].doBind();
+      el[namespace].update();
     }
   },
   unbind(el, bind, vnode) {


### PR DESCRIPTION
Bugfix:
* If the element is not in scope, you will not see it until the scroll event fires